### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/plotting_backends/security/code-scanning/5](https://github.com/GalacticDynamics/plotting_backends/security/code-scanning/5)

To resolve this, you should add an explicit `permissions` block to either the root of the workflow (to apply to all jobs), or to each job (for finer granularity). The minimal sufficient permission for these jobs are likely to be only read access to repository contents: `contents: read`. No steps shown require writing to the repository, interacting with issues or pull requests, or other elevated actions, so write access does not need to be granted. The change should be made near the top of the workflow file (e.g., after the `name:` and before `on:`) for all jobs, or directly underneath the specific job(s) if only certain jobs need reduced permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
