### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/plotting_backends/security/code-scanning/4](https://github.com/GalacticDynamics/plotting_backends/security/code-scanning/4)

**In general terms:**  
Set the permissions for the `dist` job as limited as possible, ideally to `contents: read`, unless there is evidence that more is needed.

**Detailed fix:**  
Add a `permissions:` block under the `dist` job, just like the `test-publish` and `publish` jobs already have. The minimal reasonable starting point is `contents: read`.

**Where to change:**  
Edit `.github/workflows/cd.yml`, adding the following lines directly under line 25 (that is, after `runs-on: ubuntu-latest` in the `dist` job):

```yaml
permissions:
  contents: read
```

**What is needed:**  
No imports or external dependencies are required, just a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
